### PR TITLE
fix: address critical and high security findings (SEC-001 through SEC-009)

### DIFF
--- a/images/sandbox-node-service/Dockerfile
+++ b/images/sandbox-node-service/Dockerfile
@@ -53,8 +53,15 @@ ENV NODE_ENV=development
 ENV PYTHONPATH=/opt
 ENV PYTHONUNBUFFERED=1
 
+# Create non-root user
+RUN useradd -m -s /bin/bash sandbox && \
+    chown -R sandbox:sandbox /workspace /opt/sandbox_api
+
 # Expose HTTP port for App Platform ingress
 EXPOSE 8080
+
+# Run as non-root user
+USER sandbox
 
 # Run the FastAPI server
 CMD ["python3", "-m", "uvicorn", "sandbox_api.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/images/sandbox-python-service/Dockerfile
+++ b/images/sandbox-python-service/Dockerfile
@@ -49,8 +49,15 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt
 
+# Create non-root user
+RUN useradd -m -s /bin/bash sandbox && \
+    chown -R sandbox:sandbox /workspace /opt/sandbox_api
+
 # Expose HTTP port for App Platform ingress
 EXPOSE 8080
+
+# Run as non-root user
+USER sandbox
 
 # Run the FastAPI server
 CMD ["uvicorn", "sandbox_api.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/images/sandbox_api/main.py
+++ b/images/sandbox_api/main.py
@@ -9,7 +9,9 @@ Provides HTTP/SSE endpoints for:
 """
 
 import asyncio
+import hmac
 import json
+import logging
 import os
 import time
 import uuid
@@ -17,6 +19,8 @@ import uuid
 from fastapi import Depends, FastAPI, Header, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 try:
     import httpx
@@ -31,8 +35,39 @@ app = FastAPI(title="Sandbox API", description="HTTP API for sandbox command exe
 SANDBOX_TOKEN = os.environ.get("SANDBOX_API_TOKEN", "")
 SANDBOX_MODE = os.environ.get("SANDBOX_MODE", "service")
 
+if not SANDBOX_TOKEN:
+    logger.warning("SANDBOX_API_TOKEN not set. All authenticated endpoints will reject requests.")
+
 # Process tracking for background commands
 _processes: dict[int, dict] = {}
+
+# Environment variables that must not leak to subprocesses
+_SENSITIVE_ENV_VARS = {"SANDBOX_API_TOKEN"}
+
+# Allowed filesystem roots for file operations
+_ALLOWED_ROOTS = ["/workspace", "/home/sandbox", "/tmp"]
+
+
+def _get_safe_env(user_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Build subprocess environment, stripping sensitive variables."""
+    env = {k: v for k, v in os.environ.items() if k not in _SENSITIVE_ENV_VARS}
+    if user_env:
+        env.update(user_env)
+    return env
+
+
+def _validate_path(path: str) -> str:
+    """Validate that a path is within allowed filesystem roots.
+
+    Returns the resolved real path.
+
+    Raises:
+        HTTPException: If path is outside allowed roots.
+    """
+    resolved = os.path.realpath(path)
+    if not any(resolved == root or resolved.startswith(root + "/") for root in _ALLOWED_ROOTS):
+        raise HTTPException(403, f"Access denied: path must be within {_ALLOWED_ROOTS}")
+    return resolved
 
 
 # =============================================================================
@@ -43,13 +78,13 @@ _processes: dict[int, dict] = {}
 async def verify_token(authorization: str = Header(None)):
     """Verify bearer token for protected endpoints."""
     if not SANDBOX_TOKEN:
-        return  # No token configured = allow all (development mode)
+        raise HTTPException(503, "Server not configured: SANDBOX_API_TOKEN is not set")
 
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(401, "Missing or invalid authorization header")
 
     token = authorization[7:]
-    if token != SANDBOX_TOKEN:
+    if not hmac.compare_digest(token, SANDBOX_TOKEN):
         raise HTTPException(403, "Invalid token")
 
 
@@ -89,9 +124,7 @@ class ExecResult(BaseModel):
 @app.post("/api/exec", response_model=ExecResult)
 async def exec_command(req: ExecRequest, _=Depends(verify_token)):
     """Execute a command and return the result."""
-    env = os.environ.copy()
-    if req.env:
-        env.update(req.env)
+    env = _get_safe_env(req.env)
 
     proc = await asyncio.create_subprocess_shell(
         req.command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=req.cwd, env=env
@@ -114,9 +147,7 @@ async def exec_stream(req: ExecRequest, _=Depends(verify_token)):
     """Execute a command with SSE streaming output."""
 
     async def generate():
-        env = os.environ.copy()
-        if req.env:
-            env.update(req.env)
+        env = _get_safe_env(req.env)
 
         proc = await asyncio.create_subprocess_shell(
             req.command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=req.cwd, env=env
@@ -194,9 +225,7 @@ async def exec_background(req: BackgroundExecRequest, _=Depends(verify_token)):
     """Start a background process."""
     log_file = f"/tmp/proc_{uuid.uuid4().hex[:8]}.log"
 
-    env = os.environ.copy()
-    if req.env:
-        env.update(req.env)
+    env = _get_safe_env(req.env)
 
     # Start process with nohup, redirect output to log file
     # Use subprocess.run for this quick operation to avoid async complexity
@@ -338,7 +367,10 @@ class KillRequest(BaseModel):
 
 @app.post("/api/processes/{pid}/kill")
 async def kill_process(pid: int, req: KillRequest = None, _=Depends(verify_token)):
-    """Kill a background process."""
+    """Kill a tracked background process."""
+    if pid not in _processes:
+        raise HTTPException(404, f"Process {pid} not tracked. Only processes started via /api/exec/background can be killed.")
+
     signal = req.signal if req else 15
     try:
         os.kill(pid, signal)
@@ -485,6 +517,8 @@ class FileListResponse(BaseModel):
 @app.get("/api/files")
 async def list_files(path: str = "/workspace", _=Depends(verify_token)):
     """List files in a directory."""
+    path = _validate_path(path)
+
     if not os.path.exists(path):
         raise HTTPException(404, f"Path not found: {path}")
 
@@ -511,6 +545,8 @@ async def list_files(path: str = "/workspace", _=Depends(verify_token)):
 @app.get("/api/files/content")
 async def read_file(path: str, _=Depends(verify_token)):
     """Read file content."""
+    path = _validate_path(path)
+
     if not os.path.exists(path):
         raise HTTPException(404, f"File not found: {path}")
 
@@ -539,6 +575,8 @@ class WriteFileRequest(BaseModel):
 @app.post("/api/files/content")
 async def write_file(req: WriteFileRequest, _=Depends(verify_token)):
     """Write content to a file."""
+    _validate_path(req.path)
+
     # Ensure parent directory exists
     parent = os.path.dirname(req.path)
     if parent and not os.path.exists(parent):
@@ -560,6 +598,8 @@ async def write_file(req: WriteFileRequest, _=Depends(verify_token)):
 @app.get("/api/files/download")
 async def download_file(path: str, _=Depends(verify_token)):
     """Download a file."""
+    path = _validate_path(path)
+
     if not os.path.exists(path):
         raise HTTPException(404, f"File not found: {path}")
 

--- a/src/do_app_sandbox/executor.py
+++ b/src/do_app_sandbox/executor.py
@@ -17,6 +17,28 @@ from .types import CommandResult
 # Marker used to extract exit code from command output
 EXIT_CODE_MARKER = "___EXIT_CODE___"
 
+# Pattern for valid POSIX environment variable names
+_ENV_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_env_keys(env: dict[str, str]) -> None:
+    """Validate that all environment variable keys are safe POSIX names.
+
+    Prevents shell injection via malicious key names like 'FOO;rm -rf /'.
+
+    Args:
+        env: Dictionary of environment variables to validate
+
+    Raises:
+        ValueError: If any key contains invalid characters
+    """
+    for key in env:
+        if not _ENV_KEY_PATTERN.match(key):
+            raise ValueError(
+                f"Invalid environment variable name: {key!r}. "
+                "Must match [A-Za-z_][A-Za-z0-9_]*"
+            )
+
 # Prompt patterns for different container configurations
 # The sandbox containers use a 'sandbox' user
 PROMPT_PATTERNS = [
@@ -178,6 +200,7 @@ class Executor:
 
         # Build the main command with environment variables
         if env:
+            _validate_env_keys(env)
             exports = "; ".join(f"export {k}={shlex.quote(v)}" for k, v in env.items())
             parts.append(f"{exports}; {command}")
         else:

--- a/src/do_app_sandbox/process.py
+++ b/src/do_app_sandbox/process.py
@@ -9,7 +9,7 @@ import time
 import uuid
 
 from .exceptions import CommandExecutionError
-from .executor import Executor
+from .executor import Executor, _validate_env_keys
 from .types import ProcessInfo
 
 
@@ -54,6 +54,7 @@ class ProcessManager:
         # Build the command with optional env vars
         cmd_parts = []
         if env:
+            _validate_env_keys(env)
             env_str = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
             cmd_parts.append(env_str)
         cmd_parts.append(command)

--- a/src/do_app_sandbox/sandbox.py
+++ b/src/do_app_sandbox/sandbox.py
@@ -10,6 +10,7 @@ Supports two deployment modes:
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import time
@@ -847,12 +848,13 @@ class Sandbox:
         clone_url = url
         env = None
 
+        key_path = None
         if credentials:
             if credentials.ssh_key:
-                # Write SSH key temporarily
-                key_path = "/tmp/git_key"
+                # Write SSH key to randomized path
+                key_path = f"/tmp/git_key_{uuid.uuid4().hex[:12]}"
                 self.filesystem.write_file(key_path, credentials.ssh_key)
-                self.exec(f"chmod 600 {key_path}")
+                self.exec(f"chmod 600 {shlex.quote(key_path)}")
                 env = {"GIT_SSH_COMMAND": f"ssh -i {key_path} -o StrictHostKeyChecking=no"}
             elif credentials.token:
                 # Embed token in HTTPS URL
@@ -861,11 +863,11 @@ class Sandbox:
                 clone_url = urlunparse(parsed._replace(netloc=f"{auth}@{parsed.netloc}"))
 
         cmd_parts.extend([clone_url, path])
-        result = self.exec(" ".join(cmd_parts), env=env)
+        result = self.exec(" ".join(shlex.quote(p) for p in cmd_parts), env=env)
 
         # Cleanup SSH key if used
-        if credentials and credentials.ssh_key:
-            self.exec("rm -f /tmp/git_key")
+        if key_path:
+            self.exec(f"rm -f {shlex.quote(key_path)}")
 
         return result
 

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,137 @@
+"""Unit tests for security fixes (SEC-001 through SEC-008)."""
+
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add src to path for imports
+src_path = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(src_path))
+
+from do_app_sandbox.executor import _validate_env_keys
+
+
+# =============================================================================
+# SEC-001 / SEC-008: Environment variable key validation
+# =============================================================================
+
+
+class TestValidateEnvKeys:
+    """Tests for _validate_env_keys() used in executor.py and process.py."""
+
+    def test_valid_simple_keys(self):
+        """Standard env var names should pass."""
+        _validate_env_keys({"PATH": "/usr/bin", "HOME": "/home/user", "MY_VAR": "value"})
+
+    def test_valid_underscore_prefix(self):
+        """Keys starting with underscore should pass."""
+        _validate_env_keys({"_PRIVATE": "val", "__DOUBLE": "val"})
+
+    def test_valid_single_char(self):
+        """Single character keys should pass."""
+        _validate_env_keys({"A": "1", "_": "2"})
+
+    def test_valid_alphanumeric_mix(self):
+        """Keys with letters, digits, and underscores should pass."""
+        _validate_env_keys({"VAR123": "v", "A1_B2_C3": "v", "x": "v"})
+
+    def test_empty_dict(self):
+        """Empty dict should pass without error."""
+        _validate_env_keys({})
+
+    def test_rejects_semicolon_injection(self):
+        """Key with semicolon (shell command separator) must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"FOO;rm -rf /": "val"})
+
+    def test_rejects_equals_in_key(self):
+        """Key containing = must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"FOO=BAR": "val"})
+
+    def test_rejects_space_in_key(self):
+        """Key containing spaces must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"FOO BAR": "val"})
+
+    def test_rejects_leading_digit(self):
+        """Key starting with a digit must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"1VAR": "val"})
+
+    def test_rejects_backtick_injection(self):
+        """Key with backtick (command substitution) must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"`whoami`": "val"})
+
+    def test_rejects_dollar_injection(self):
+        """Key with $ (variable expansion) must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"$HOME": "val"})
+
+    def test_rejects_newline_injection(self):
+        """Key with newline must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"FOO\nBAR": "val"})
+
+    def test_rejects_pipe_injection(self):
+        """Key with pipe (command chaining) must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"FOO|cat /etc/passwd": "val"})
+
+    def test_rejects_empty_key(self):
+        """Empty string key must be rejected."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"": "val"})
+
+    def test_rejects_hyphen_in_key(self):
+        """Key with hyphen must be rejected (not valid POSIX)."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"MY-VAR": "val"})
+
+    def test_first_invalid_key_raises(self):
+        """When mix of valid and invalid, should raise on the invalid one."""
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            _validate_env_keys({"GOOD": "val", "BAD;evil": "val"})
+
+
+# =============================================================================
+# SEC-006: Git checkout command quoting
+# =============================================================================
+
+
+class TestGitCheckoutQuoting:
+    """Tests that git clone commands are properly shell-quoted."""
+
+    def test_url_with_spaces_is_quoted(self):
+        """URLs with special characters should be properly quoted."""
+        parts = ["git", "clone", "--depth", "1", "https://example.com/repo with spaces.git", "/workspace"]
+        quoted_cmd = " ".join(shlex.quote(p) for p in parts)
+        # Verify the URL with spaces is quoted
+        assert "repo with spaces" not in quoted_cmd.split()  # Not split on space
+        assert "'https://example.com/repo with spaces.git'" in quoted_cmd or \
+               '"https://example.com/repo with spaces.git"' in quoted_cmd or \
+               "https://example.com/repo\\ with\\ spaces.git" in quoted_cmd
+
+    def test_url_with_shell_metacharacters_is_quoted(self):
+        """URLs with shell metacharacters should be safely quoted."""
+        malicious_url = "https://evil.com/repo;rm -rf /"
+        parts = ["git", "clone", malicious_url, "/workspace"]
+        quoted_cmd = " ".join(shlex.quote(p) for p in parts)
+        # The semicolon should be escaped/quoted, not interpreted as command separator
+        assert ";rm" not in quoted_cmd or "'" in quoted_cmd
+
+    def test_path_with_special_chars_is_quoted(self):
+        """Destination paths with special chars should be quoted."""
+        parts = ["git", "clone", "https://github.com/user/repo.git", "/workspace/my project"]
+        quoted_cmd = " ".join(shlex.quote(p) for p in parts)
+        assert "'/workspace/my project'" in quoted_cmd or '"/workspace/my project"' in quoted_cmd
+
+    def test_normal_url_roundtrips(self):
+        """Normal URLs without special chars should work unchanged."""
+        url = "https://github.com/user/repo.git"
+        parts = ["git", "clone", "--depth", "1", url, "/workspace"]
+        quoted_cmd = " ".join(shlex.quote(p) for p in parts)
+        assert url in quoted_cmd


### PR DESCRIPTION
## Summary

Fixes all **3 CRITICAL** and **5 HIGH** severity findings from the [security review](https://github.com/bikramkgupta/security-review-do-app-sandbox), plus 1 bonus MEDIUM fix. Includes 20 new unit tests.

### A note on severity in the sandbox context

The original severity ratings come from the raw security review. However, **this is an ephemeral sandbox designed to run untrusted code** — the container exists to execute arbitrary commands and gets deleted after use. This fundamentally changes the threat model:

- **Untrusted code already has shell access via `exec()`** — so restricting the file API or kill API doesn't add meaningful security when `exec("cat /etc/passwd")` or `exec("kill -9 1")` works by design.
- **Root vs non-root inside an ephemeral container** doesn't change the blast radius — the container gets deleted anyway, and there's no privilege escalation to the host.
- **The SDK caller is the developer**, not the untrusted code — so env key validation and git URL quoting are code correctness issues, not escalation paths.

The one finding that genuinely crosses a trust boundary is **SEC-002 (auth bypass)** — it controls *who gets into the sandbox*, which is the real security gate.

All fixes are still good code hygiene and worth shipping. The revised severities below reflect the actual risk in this threat model.

## Fixes

| Finding | Original Severity | Revised Severity | Fix | |---|---|---|---|
| **SEC-002** | CRITICAL | **HIGH** | Fail closed when \`SANDBOX_API_TOKEN\` is unset — return HTTP 503 instead of allowing all requests. This is the real security gate: it controls who can access the sandbox's public URL. |
| **SEC-001** | CRITICAL | **MEDIUM** | Validate env var keys in \`executor._build_command()\` — reject keys with shell metacharacters. Code correctness fix; the SDK caller (developer) provides these, not untrusted code. |
| **SEC-008** | HIGH | **MEDIUM** | Validate env var keys in \`process.launch()\` — reuses \`_validate_env_keys()\`. Same reasoning as SEC-001. |
| **SEC-007** | HIGH | **MEDIUM** | Strip \`SANDBOX_API_TOKEN\` from subprocess environments via \`_get_safe_env()\`. Defense-in-depth; the token only grants access to the same sandbox the code is already running in. |
| **SEC-003** | CRITICAL | **LOW** | Run service containers as non-root \`sandbox\` user. Untrusted code can already do anything inside the ephemeral container via exec; root vs non-root doesn't change blast radius. |
| **SEC-004** | HIGH | **LOW** | Restrict file API paths to \`/workspace\`, \`/home/sandbox\`, \`/tmp\`. The exec endpoint can already access any file, so this is cosmetic in the sandbox context. |
| **SEC-005** | HIGH | **LOW** | Restrict kill endpoint to tracked PIDs only. Same reasoning — exec can already run \`kill\` on any PID. |
| **SEC-006** | HIGH | **LOW** | Shell-quote git clone URL/path parts, randomize SSH key path. The git URL comes from the SDK caller (developer), not untrusted input. |
| **SEC-009** | MEDIUM | **LOW** | Use \`hmac.compare_digest()\` for timing-safe token comparison. Timing attacks require thousands of precise measurements; theoretical against ephemeral sandboxes with network jitter. |

## Files Changed

| File | Changes |
|---|---|
| \`src/do_app_sandbox/executor.py\` | Add \`_validate_env_keys()\` with POSIX regex, call in \`_build_command()\` |
| \`src/do_app_sandbox/process.py\` | Import and call \`_validate_env_keys()\` in \`launch()\` |
| \`src/do_app_sandbox/sandbox.py\` | Quote git clone parts with \`shlex.quote()\`, randomize SSH key path |
| \`images/sandbox_api/main.py\` | Auth bypass fix, timing-safe comparison, path validation, PID restriction, env filtering |
| \`images/sandbox-python-service/Dockerfile\` | Add non-root \`sandbox\` user and \`USER\` directive |
| \`images/sandbox-node-service/Dockerfile\` | Add non-root \`sandbox\` user and \`USER\` directive |
| \`tests/unit/test_security.py\` | 20 new unit tests for env key validation and git command quoting |

## Remaining Findings (22 open)

<details>
<summary>Full findings table from security review (31 total) — with revised severities</summary>

| ID | Original | Revised | Title | Status |
|---|---|---|---|---|
| SEC-001 | CRITICAL | MEDIUM | Env var key injection in executor.py | ✅ Fixed |
| SEC-002 | CRITICAL | **HIGH** | Auth bypass when API token unset | ✅ Fixed |
| SEC-003 | CRITICAL | LOW | Service containers run as root | ✅ Fixed |
| SEC-004 | HIGH | LOW | Unrestricted file path access in service API | ✅ Fixed |
| SEC-005 | HIGH | LOW | Kill endpoint targets any system process | ✅ Fixed |
| SEC-006 | HIGH | LOW | Git clone URL not shell-quoted | ✅ Fixed |
| SEC-007 | HIGH | MEDIUM | API token leaked via subprocess env | ✅ Fixed |
| SEC-008 | HIGH | MEDIUM | Env key injection in process launch | ✅ Fixed |
| SEC-009 | MEDIUM | LOW | Non-timing-safe token comparison | ✅ Fixed |
| SEC-010 | MEDIUM | — | Snapshot tar params not shell-quoted | Open |
| SEC-011 | MEDIUM | — | No integrity verification for base64 transfers | Open |
| SEC-012 | MEDIUM | — | No integrity verification for snapshots | Open |
| SEC-013 | MEDIUM | — | Mutable Docker image tags | Open |
| SEC-014 | MEDIUM | — | Installer scripts without integrity verification | Open |
| SEC-015 | MEDIUM | — | Container dependencies ~2 years old | Open |
| SEC-016 | MEDIUM | — | No rate limiting on API endpoints | Open |
| SEC-017 | MEDIUM | — | Unlimited session creation | Open |
| SEC-018 | MEDIUM | — | Worker containers have passwordless sudo | Open |
| SEC-019 | MEDIUM | — | Port proxy enables SSRF to localhost | Open |
| SEC-020 | MEDIUM | — | Presigned URLs visible in process listings | Open |
| SEC-021 | MEDIUM | LOW | SSH key written to predictable path | ✅ Fixed (SEC-006) |
| SEC-022 | MEDIUM | — | SSH StrictHostKeyChecking disabled | Open |
| SEC-023 | MEDIUM | — | Chmod mode parameter not shell-quoted | Open |
| SEC-024 | LOW | — | No authentication failure logging | Open |
| SEC-025 | LOW | — | No audit logging | Open |
| SEC-026 | LOW | — | Unpinned apt package versions | Open |
| SEC-027 | LOW | — | No Docker base image digest pinning | Open |
| SEC-028 | LOW | — | Missing exception chaining | Open |
| SEC-029 | INFO | — | Version mismatch | Open |
| SEC-030 | INFO | — | Global S108 suppression | Open |
| SEC-031 | INFO | — | Global BLE001 suppression | Open |

</details>

## Test plan

- [x] All 20 new security unit tests pass
- [x] All 168 existing unit tests pass (188 total)
- [ ] Rebuild service Docker images and verify non-root user
- [ ] Deploy service-mode sandbox and verify auth rejection when token unset
- [ ] Verify file API rejects paths outside allowed roots

🤖 Generated with [Claude Code](https://claude.com/claude-code)